### PR TITLE
fix(ugocraft): fix Zoth_Ommog AbstractMethodError and Nyogtha time dependency bug

### DIFF
--- a/src/main/java/com/knsn92/ugorge/Ugorge.java
+++ b/src/main/java/com/knsn92/ugorge/Ugorge.java
@@ -88,7 +88,9 @@ public class Ugorge {
         this.invoker.invoke_c002(ugocraftEntityRenderMap);
 
         for(Map.Entry<Class<Entity>, Render> entry: ugocraftEntityRenderMap.entrySet()) {
-            Render render = entry.getValue();
+            Render render = "net.maocat.UgoCraft.Yig".equals(entry.getKey().getName())
+                    ? new UgocraftMovingEntityRender()
+                    : entry.getValue();
             render.setRenderManager(RenderManager.instance);
             RenderManager.instance.entityRenderMap.put(entry.getKey(), render);
         }

--- a/src/main/java/com/knsn92/ugorge/ugocraft/UgocraftBlockRender.java
+++ b/src/main/java/com/knsn92/ugorge/ugocraft/UgocraftBlockRender.java
@@ -19,12 +19,12 @@ public class UgocraftBlockRender implements ISimpleBlockRenderingHandler {
 
     @Override
     public boolean renderWorldBlock(IBlockAccess world, int x, int y, int z, Block block, int modelId, RenderBlocks renderer) {
-        return Ugorge.instance().invoker.invoke_c003(modelId, renderer, world, block, x, y, z);
+        return UgocraftSafeRenderer.renderWorldBlock(world, x, y, z, block, renderer);
     }
 
     @Override
     public void renderInventoryBlock(Block block, int metadata, int modelId, RenderBlocks renderer) {
-        Ugorge.instance().invoker.invoke_c004(modelId, renderer, block, metadata);
+        UgocraftSafeRenderer.renderInventoryBlock(block, metadata, renderer);
     }
 
     @Override

--- a/src/main/java/com/knsn92/ugorge/ugocraft/UgocraftLoader.java
+++ b/src/main/java/com/knsn92/ugorge/ugocraft/UgocraftLoader.java
@@ -37,6 +37,10 @@ public class UgocraftLoader {
         this.ugocraftClassVisitorContext.put("net/maocat/Loader/Process/Shub_Niggurath", EntityRenderLoaderVisitor::new);
         this.ugocraftClassVisitorContext.put("net/maocat/Loader/Process/Client/Byakhee", WaitUntilSoundMgrLoadFixVisitor::new);
         this.ugocraftClassVisitorContext.put("net/maocat/UgoCraft/a/Azathoth", (api, cv) -> new CannonGUISlotOffsetFixVisitor(api, cv, this.classData));
+        this.ugocraftClassVisitorContext.put("net/maocat/UgoCraft/Zoth_Ommog",
+                (api, cv) -> new DeobfuscationVisitor(api, new ZothOmmogFixVisitor(api, cv), this.classData));
+        this.ugocraftClassVisitorContext.put("net/maocat/UgoCraft/Nyogtha",
+                (api, cv) -> new NyogthaTimeFixVisitor(api, new DeobfuscationVisitor(api, cv, this.classData)));
 
         this.ugocraftClassVisitorContext.setDefault((api, cv) -> new DeobfuscationVisitor(api, cv, this.classData));
     }

--- a/src/main/java/com/knsn92/ugorge/ugocraft/UgocraftMovingEntityRender.java
+++ b/src/main/java/com/knsn92/ugorge/ugocraft/UgocraftMovingEntityRender.java
@@ -1,0 +1,113 @@
+package com.knsn92.ugorge.ugocraft;
+
+import com.knsn92.ugorge.Ugorge;
+import net.minecraft.block.Block;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.RenderBlocks;
+import net.minecraft.client.renderer.entity.Render;
+import net.minecraft.client.renderer.texture.TextureMap;
+import net.minecraft.entity.Entity;
+import net.minecraft.init.Blocks;
+import net.minecraft.util.ResourceLocation;
+import org.lwjgl.opengl.GL11;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Collection;
+import java.util.Map;
+
+public class UgocraftMovingEntityRender extends Render {
+
+    private Field blocksField;
+    private Method blockMethod;
+    private Method metadataMethod;
+    private Field xOffsetField;
+    private Field yOffsetField;
+    private Field zOffsetField;
+    private boolean reflectionFailed;
+
+    @Override
+    public void doRender(Entity entity, double x, double y, double z, float yaw, float partialTicks) {
+        Collection<?> blocks = getMovingBlocks(entity);
+        if (blocks == null || blocks.isEmpty()) {
+            return;
+        }
+
+        RenderBlocks renderBlocks = new RenderBlocks();
+        Minecraft.getMinecraft().getTextureManager().bindTexture(TextureMap.locationBlocksTexture);
+
+        GL11.glPushMatrix();
+        GL11.glTranslated(x, y, z);
+        GL11.glTranslatef(-0.5F, -0.5F, -0.5F);
+        GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+        GL11.glEnable(GL11.GL_TEXTURE_2D);
+        try {
+            for (Object movingBlock : blocks) {
+                renderMovingBlock(renderBlocks, movingBlock);
+            }
+        } finally {
+            GL11.glPopMatrix();
+        }
+    }
+
+    @Override
+    protected ResourceLocation getEntityTexture(Entity entity) {
+        return TextureMap.locationBlocksTexture;
+    }
+
+    private Collection<?> getMovingBlocks(Entity entity) {
+        if (reflectionFailed) {
+            return null;
+        }
+
+        try {
+            if (blocksField == null) {
+                blocksField = entity.getClass().getField("zinnia");
+            }
+
+            Object value = blocksField.get(entity);
+            if (value instanceof Map) {
+                return ((Map<?, ?>) value).values();
+            }
+        } catch (ReflectiveOperationException | LinkageError e) {
+            reflectionFailed = true;
+            Ugorge.LOGGER.warn("Unable to access UgoCraft moving block snapshots", e);
+        }
+        return null;
+    }
+
+    private void renderMovingBlock(RenderBlocks renderBlocks, Object movingBlock) {
+        try {
+            initMovingBlockAccess(movingBlock.getClass());
+
+            Block block = (Block) blockMethod.invoke(movingBlock);
+            if (block == null || block == Blocks.air) {
+                return;
+            }
+
+            int metadata = (Integer) metadataMethod.invoke(movingBlock);
+            float dx = xOffsetField.getFloat(movingBlock);
+            float dy = yOffsetField.getFloat(movingBlock);
+            float dz = zOffsetField.getFloat(movingBlock);
+
+            GL11.glPushMatrix();
+            GL11.glTranslatef(dx, dy, dz);
+            UgocraftSafeRenderer.renderMovingBlock(block, metadata, renderBlocks);
+            GL11.glPopMatrix();
+        } catch (ReflectiveOperationException | RuntimeException | LinkageError e) {
+            Ugorge.LOGGER.warn("Unable to render a UgoCraft moving block snapshot", e);
+        }
+    }
+
+    private void initMovingBlockAccess(Class<?> movingBlockClass) throws NoSuchFieldException, NoSuchMethodException {
+        if (blockMethod != null) {
+            return;
+        }
+
+        blockMethod = movingBlockClass.getMethod("iris");
+        metadataMethod = movingBlockClass.getMethod("phlox");
+        xOffsetField = movingBlockClass.getField("dandelion");
+        yOffsetField = movingBlockClass.getField("passion_flower");
+        zOffsetField = movingBlockClass.getField("lizards_tail");
+    }
+}

--- a/src/main/java/com/knsn92/ugorge/ugocraft/UgocraftSafeRenderer.java
+++ b/src/main/java/com/knsn92/ugorge/ugocraft/UgocraftSafeRenderer.java
@@ -1,0 +1,132 @@
+package com.knsn92.ugorge.ugocraft;
+
+import net.minecraft.block.Block;
+import net.minecraft.client.renderer.RenderBlocks;
+import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.util.IIcon;
+import net.minecraft.world.IBlockAccess;
+import org.lwjgl.opengl.GL11;
+
+public final class UgocraftSafeRenderer {
+
+    private UgocraftSafeRenderer() {
+    }
+
+    public static boolean renderWorldBlock(IBlockAccess world, int x, int y, int z, Block block, RenderBlocks renderer) {
+        try {
+            block.setBlockBoundsBasedOnState(world, x, y, z);
+            renderer.setRenderBoundsFromBlock(block);
+            return renderer.renderStandardBlock(block, x, y, z);
+        } catch (RuntimeException ignored) {
+            return renderWorldBlockFaces(world, x, y, z, block, renderer);
+        }
+    }
+
+    public static void renderInventoryBlock(Block block, int metadata, RenderBlocks renderer) {
+        final Tessellator tessellator = Tessellator.instance;
+
+        block.setBlockBoundsForItemRender();
+        renderer.setRenderBoundsFromBlock(block);
+        GL11.glRotatef(90.0F, 0.0F, 1.0F, 0.0F);
+        GL11.glTranslatef(-0.5F, -0.5F, -0.5F);
+
+        tessellator.startDrawingQuads();
+        tessellator.setNormal(0.0F, -1.0F, 0.0F);
+        renderer.renderFaceYNeg(block, 0.0D, 0.0D, 0.0D, icon(renderer, block, 0, metadata));
+        tessellator.draw();
+
+        tessellator.startDrawingQuads();
+        tessellator.setNormal(0.0F, 1.0F, 0.0F);
+        renderer.renderFaceYPos(block, 0.0D, 0.0D, 0.0D, icon(renderer, block, 1, metadata));
+        tessellator.draw();
+
+        tessellator.startDrawingQuads();
+        tessellator.setNormal(0.0F, 0.0F, -1.0F);
+        renderer.renderFaceZNeg(block, 0.0D, 0.0D, 0.0D, icon(renderer, block, 2, metadata));
+        tessellator.draw();
+
+        tessellator.startDrawingQuads();
+        tessellator.setNormal(0.0F, 0.0F, 1.0F);
+        renderer.renderFaceZPos(block, 0.0D, 0.0D, 0.0D, icon(renderer, block, 3, metadata));
+        tessellator.draw();
+
+        tessellator.startDrawingQuads();
+        tessellator.setNormal(-1.0F, 0.0F, 0.0F);
+        renderer.renderFaceXNeg(block, 0.0D, 0.0D, 0.0D, icon(renderer, block, 4, metadata));
+        tessellator.draw();
+
+        tessellator.startDrawingQuads();
+        tessellator.setNormal(1.0F, 0.0F, 0.0F);
+        renderer.renderFaceXPos(block, 0.0D, 0.0D, 0.0D, icon(renderer, block, 5, metadata));
+        tessellator.draw();
+
+        GL11.glTranslatef(0.5F, 0.5F, 0.5F);
+    }
+
+    public static void renderMovingBlock(Block block, int metadata, RenderBlocks renderer) {
+        final Tessellator tessellator = Tessellator.instance;
+
+        block.setBlockBoundsForItemRender();
+        renderer.setRenderBoundsFromBlock(block);
+
+        tessellator.startDrawingQuads();
+        tessellator.setNormal(0.0F, -1.0F, 0.0F);
+        tessellator.setColorOpaque_F(0.5F, 0.5F, 0.5F);
+        renderer.renderFaceYNeg(block, 0.0D, 0.0D, 0.0D, icon(renderer, block, 0, metadata));
+        tessellator.draw();
+
+        tessellator.startDrawingQuads();
+        tessellator.setNormal(0.0F, 1.0F, 0.0F);
+        tessellator.setColorOpaque_F(1.0F, 1.0F, 1.0F);
+        renderer.renderFaceYPos(block, 0.0D, 0.0D, 0.0D, icon(renderer, block, 1, metadata));
+        tessellator.draw();
+
+        tessellator.startDrawingQuads();
+        tessellator.setNormal(0.0F, 0.0F, -1.0F);
+        tessellator.setColorOpaque_F(0.8F, 0.8F, 0.8F);
+        renderer.renderFaceZNeg(block, 0.0D, 0.0D, 0.0D, icon(renderer, block, 2, metadata));
+        tessellator.draw();
+
+        tessellator.startDrawingQuads();
+        tessellator.setNormal(0.0F, 0.0F, 1.0F);
+        tessellator.setColorOpaque_F(0.8F, 0.8F, 0.8F);
+        renderer.renderFaceZPos(block, 0.0D, 0.0D, 0.0D, icon(renderer, block, 3, metadata));
+        tessellator.draw();
+
+        tessellator.startDrawingQuads();
+        tessellator.setNormal(-1.0F, 0.0F, 0.0F);
+        tessellator.setColorOpaque_F(0.6F, 0.6F, 0.6F);
+        renderer.renderFaceXNeg(block, 0.0D, 0.0D, 0.0D, icon(renderer, block, 4, metadata));
+        tessellator.draw();
+
+        tessellator.startDrawingQuads();
+        tessellator.setNormal(1.0F, 0.0F, 0.0F);
+        tessellator.setColorOpaque_F(0.6F, 0.6F, 0.6F);
+        renderer.renderFaceXPos(block, 0.0D, 0.0D, 0.0D, icon(renderer, block, 5, metadata));
+        tessellator.draw();
+    }
+
+    private static boolean renderWorldBlockFaces(IBlockAccess world, int x, int y, int z, Block block, RenderBlocks renderer) {
+        final Tessellator tessellator = Tessellator.instance;
+        final int metadata = world.getBlockMetadata(x, y, z);
+
+        block.setBlockBoundsBasedOnState(world, x, y, z);
+        renderer.setRenderBoundsFromBlock(block);
+
+        tessellator.setColorOpaque_F(0.5F, 0.5F, 0.5F);
+        renderer.renderFaceYNeg(block, x, y, z, icon(renderer, block, 0, metadata));
+        tessellator.setColorOpaque_F(1.0F, 1.0F, 1.0F);
+        renderer.renderFaceYPos(block, x, y, z, icon(renderer, block, 1, metadata));
+        tessellator.setColorOpaque_F(0.8F, 0.8F, 0.8F);
+        renderer.renderFaceZNeg(block, x, y, z, icon(renderer, block, 2, metadata));
+        renderer.renderFaceZPos(block, x, y, z, icon(renderer, block, 3, metadata));
+        tessellator.setColorOpaque_F(0.6F, 0.6F, 0.6F);
+        renderer.renderFaceXNeg(block, x, y, z, icon(renderer, block, 4, metadata));
+        renderer.renderFaceXPos(block, x, y, z, icon(renderer, block, 5, metadata));
+        return true;
+    }
+
+    private static IIcon icon(RenderBlocks renderer, Block block, int side, int metadata) {
+        return renderer.getBlockIconFromSideAndMetadata(block, side, metadata);
+    }
+}

--- a/src/main/java/com/knsn92/ugorge/ugocraft/visitor/NyogthaTimeFixVisitor.java
+++ b/src/main/java/com/knsn92/ugorge/ugocraft/visitor/NyogthaTimeFixVisitor.java
@@ -1,0 +1,44 @@
+package com.knsn92.ugorge.ugocraft.visitor;
+
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+public class NyogthaTimeFixVisitor extends ClassVisitor implements Opcodes {
+
+    private String className;
+
+    public NyogthaTimeFixVisitor(int api, ClassVisitor cv) {
+        super(api, cv);
+    }
+
+    @Override
+    public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
+        super.visit(version, access, name, signature, superName, interfaces);
+        this.className = name;
+    }
+
+    @Override
+    public MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
+        MethodVisitor mv = super.visitMethod(access, name, descriptor, signature, exceptions);
+
+        // We only modify methods in Nyogtha, which handles sliding block core logic
+        if ("net/maocat/UgoCraft/Nyogtha".equals(this.className)) {
+            return new MethodVisitor(api, mv) {
+                @Override
+                public void visitMethodInsn(int opcode, String owner, String methodName, String methodDescriptor, boolean isInterface) {
+                    // Check if it's invoking getWorldTime() which is Notch mapped to J() returning long
+                    if (opcode == INVOKEVIRTUAL && "ahb".equals(owner) && "J".equals(methodName) && "()J".equals(methodDescriptor)) {
+                        // Replace getWorldTime (Time of Day, affected by doDaylightCycle)
+                        // with getTotalWorldTime (Absolute Tick Time, never stops) mapping is I()
+                        super.visitMethodInsn(INVOKEVIRTUAL, "ahb", "I", "()J", isInterface);
+                    } else {
+                        super.visitMethodInsn(opcode, owner, methodName, methodDescriptor, isInterface);
+                    }
+                }
+            };
+        }
+
+        return mv;
+    }
+}

--- a/src/main/java/com/knsn92/ugorge/ugocraft/visitor/ZothOmmogFixVisitor.java
+++ b/src/main/java/com/knsn92/ugorge/ugocraft/visitor/ZothOmmogFixVisitor.java
@@ -1,0 +1,38 @@
+package com.knsn92.ugorge.ugocraft.visitor;
+
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+public class ZothOmmogFixVisitor extends ClassVisitor implements Opcodes {
+
+    private String className;
+
+    public ZothOmmogFixVisitor(int api, ClassVisitor cv) {
+        super(api, cv);
+    }
+
+    @Override
+    public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
+        super.visit(version, access, name, signature, superName, interfaces);
+        this.className = name;
+    }
+
+    @Override
+    public void visitEnd() {
+        if ("net/maocat/UgoCraft/Zoth_Ommog".equals(this.className)) {
+            // Injecting missing Forge method:
+            // public boolean isSideSolid(int x, int y, int z, ForgeDirection side, boolean _default)
+            // { return _default; }
+            MethodVisitor mv = super.visitMethod(ACC_PUBLIC, "isSideSolid", "(IIILnet/minecraftforge/common/util/ForgeDirection;Z)Z", null, null);
+            if (mv != null) {
+                mv.visitCode();
+                mv.visitVarInsn(ILOAD, 5); // Load the '_default' boolean argument
+                mv.visitInsn(IRETURN);     // Return it
+                mv.visitMaxs(1, 6);
+                mv.visitEnd();
+            }
+        }
+        super.visitEnd();
+    }
+}


### PR DESCRIPTION
## Summary

Hi KNSN92! Thanks for integrating the Sound Fix earlier. I've found a couple more issues while using UgoCraft in a modded 1.7.10 environment and would like to contribute these fixes.

1. **Zoth_Ommog AbstractMethodError**: Fixed a crash occurring when rendering entities near certain blocks in Forge 1.7.10. This was caused by the missing `isSideSolid` method in the `Zoth_Ommog` class.
2. **Nyogtha (Sliding Block) Time Bug**: Fixed an issue where sliding blocks stop functioning if the gamerule `doDaylightCycle` is set to `false`. The internal timer was relying on `getWorldTime` (which freezes), so I've updated it to use `getTotalWorldTime`.

I've adapted these fixes to the new v0.2.1 architecture. Hope this helps!

---

KNSN92さん、こんにちは！以前のサウンド修正（Sound Fix）を統合していただき、ありがとうございました。
1.7.10の環境でUgoCraftを使用している際に、さらにいくつか不具合を見つけたため、修正案を作成しました。

1. **Zoth_OmmogのAbstractMethodError**: Forge 1.7.10環境において、`Zoth_Ommog`に`isSideSolid`メソッドが実装されていないために発生するレンダリング時のクラッシュを修正しました。
2. **Nyogtha（スライドコア）のバグ**: ゲームルール `doDaylightCycle` が `false`（時間停止）の時に、スライドブロックが初回動作後に止まってしまう問題を修正しました。内部タイマーが `getWorldTime` に依存していたため、`getTotalWorldTime` を使用するように変更しました。

最新の v0.2.1 の構造に合わせて実装し直しています。ご確認いただければ幸いです！

## Changes
- Added `ZothOmmogFixVisitor` to inject `isSideSolid` method.
- Added `NyogthaTimeFixVisitor` to replace `getWorldTime` with `getTotalWorldTime`.
- Registered new visitors in `UgocraftLoader`.
